### PR TITLE
Replace Python helpers with Bash equivalents

### DIFF
--- a/TECHNICAL_README.md
+++ b/TECHNICAL_README.md
@@ -22,7 +22,7 @@ This document explains how `live_yap.sh` captures, transcribes, and optionally t
 ## Audio Chunking Strategy
 
 - `ffmpeg` is launched once with `-f avfoundation` (macOS-specific) and `-f segment -segment_time SEG_SECONDS`, keeping latency low without reinitializing hardware.
-- A fractional `msleep` helper wraps `/bin/sleep`, Perl, and Python fallbacks because macOS' BSD `sleep` rejects sub-second arguments in some environments. The Python path now receives the requested delay explicitly so that falling back continues to sleep instead of aborting when `/bin/sleep` is unavailable.
+- A fractional `msleep` helper first tries `/bin/sleep`, then falls back to a Perl `select()` call, and finally emulates fractional delays with pure Bash parsing plus `usleep` when available. The layered approach keeps the loop responsive even when BSD `sleep` rejects decimal arguments.
 - `fswatch -0` streams null-delimited filenames so paths containing spaces are handled correctly.
 
 ### Technical Challenge: Low-Latency Capture Without Busy Waiting
@@ -33,7 +33,7 @@ The script must react to new audio segments in under a few hundred milliseconds,
 
 - Each `.wav` chunk is passed to `yap transcribe --locale SOURCE_LOCALE` and stripped of NUL bytes, leading/trailing whitespace, and repeated spaces.
 - Chunks that fail transcription simply continue the loop rather than aborting the session, despite `set -e`, to avoid terminating long recordings because of transient errors.
-- A short Python `unicodedata` probe ensures that the cleaned text contains letters or numbers before displaying it. This filters out silence or punctuation-only artifacts, keeping the transcript readable.
+- A Bash `has_meaningful_text` helper trims whitespace, looks for ASCII alphanumerics, then permits any non-ASCII glyphs (covering CJK, emoji, etc.). Chunks that only contain punctuation are dropped so the on-screen transcript stays readable.
 
 ### Technical Challenge: Balancing Accuracy and Resilience
 


### PR DESCRIPTION
## Summary
- replace the Python-based timing fallback with a Bash implementation that prefers `/bin/sleep`, Perl, and optional `usleep`
- add a Bash `has_meaningful_text` helper so the transcription filter no longer shells out to Python
- document the updated helpers in `TECHNICAL_README.md`

## Testing
- bash -n live_yap.sh
- shellcheck live_yap.sh


------
https://chatgpt.com/codex/tasks/task_e_68d12b3b86c0832bafb94672c2bce8c0